### PR TITLE
write output to bigquery

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pydantic >= 2.10.3
 pytest
+google-cloud-bigquery


### PR DESCRIPTION
### TL;DR

Added BigQuery integration to export risk scores directly to a BigQuery table.

### What changed?

- Added `google-cloud-bigquery` to requirements.txt
- Implemented a new `write_to_bigquery()` function that formats and exports risk score data
- Modified the `process_input_data()` function to collect V22 and V28 risk scores and HCCs for BigQuery export
- Added graceful handling when BigQuery library is not available

### How to test?

1. Install the new dependency: `pip install google-cloud-bigquery`
2. Run the quick_start script with proper GCP authentication
3. Verify that risk scores are written to the `sgv_reporting.risk_scores` table
4. Check that the table contains MRN, risk scores, and HCC lists for both V22 and V28 models

### Why make this change?

This integration streamlines the workflow by automatically exporting calculated risk scores to BigQuery, eliminating manual data transfer steps. The data is properly formatted with appropriate schema definitions, ensuring consistent data types and structure in the BigQuery table.